### PR TITLE
export queryExtend as an AMD module when define && define.amd is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "gulp": "^3.8.7",
     "gulp-concat": "^2.3.4",
     "gulp-uglify": "^0.3.1",
-    "mocha": "^1.21.3"
+    "mocha": "^1.21.3",
+    "requirejs": "^2.1.15"
   },
   "scripts": {
     "test": "mocha tests.js"

--- a/query-extend.js
+++ b/query-extend.js
@@ -113,12 +113,16 @@
 
   };
 
-  // Node.js / browserify
   if (typeof module !== 'undefined' && module.exports) {
+    // Node.js / browserify
     module.exports = queryExtend;
-  }
-  // <script>
-  else {
+  } else if  (typeof define === 'function' && define.amd) {
+    // require.js / AMD
+    define(function() {
+      return queryExtend;
+    });
+  } else {
+    // <script>
     glob.queryExtend = queryExtend;
   }
 

--- a/tests.js
+++ b/tests.js
@@ -20,4 +20,14 @@ describe('query-extend', function() {
     expect(queryExtend('?per_page=2&foo=bar', '?foo=test', true).foo).to.be.equal('test');
     expect(queryExtend('?foo[]=bar', true).foo[0]).to.be.equal('bar');
   });
+  it('exports an AMD module', function(done) {
+    var requirejs = require('requirejs');
+    requirejs.config({
+      baseUrl : '.'
+    });
+    requirejs(['query-extend'], function(queryExtend){
+      expect(queryExtend).to.be.a(Function);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
As it's not at all expensive, I think it'd be nice to have the library export `queryExtend` as an AMD module in an AMD environment.
